### PR TITLE
Fix builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ It has 0 dependencies and works out of the box in any modern browser, for synchr
 Keep in mind that the providers detected by this package may or may not support [the Ethereum JavaScript Provider API](https://eips.ethereum.org/EIPS/eip-1193).
 Please consult [the MetaMask documentation](https://docs.metamask.io/guide/ethereum-provider.html) to learn how to use our provider.
 
+### Node.js
+
 ```javascript
 import detectEthereumProvider from '@metamask/detect-provider'
 
@@ -32,6 +34,21 @@ if (provider) {
   // if the provider is not detected, detectEthereumProvider resolves to null
   console.error('Please install MetaMask!', error)
 }
+```
+
+### HTML
+
+```html
+<script href="https://unpkg.com/@metamask/detect-provider/dist/detect-provider.min.js"></script>
+<script type="text/javascript">
+  const provider = await detectEthereumProvider()
+
+  if (provider) {
+    // handle provider
+  } else {
+    // handle no provider
+  }
+</script>
 ```
 
 ### Options

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ if (provider) {
 ### HTML
 
 ```html
-<script href="https://unpkg.com/@metamask/detect-provider/dist/detect-provider.min.js"></script>
+<script src="https://unpkg.com/@metamask/detect-provider/dist/detect-provider.min.js"></script>
 <script type="text/javascript">
   const provider = await detectEthereumProvider()
 

--- a/build.sh
+++ b/build.sh
@@ -4,8 +4,7 @@ set -u
 set -e
 set -o pipefail
 
-BROWSERIFY_PATH="./node_modules/browserify/bin/cmd.js"
-BROWSERIFY_CMD="node ${BROWSERIFY_PATH} -s detectEthereumProvider"
+BROWSERIFY_CMD="browserify -s detectEthereumProvider"
 
 mkdir -p ./dist
 rm -rf ./dist/*

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -u
+set -e
+set -o pipefail
+
+BROWSERIFY_PATH="./node_modules/browserify/bin/cmd.js"
+BROWSERIFY_CMD="node ${BROWSERIFY_PATH} -s detectEthereumProvider"
+
+mkdir -p ./dist
+rm -rf ./dist/*
+
+$BROWSERIFY_CMD index.js > dist/detect-provider.js
+$BROWSERIFY_CMD -g uglifyify index.js > dist/detect-provider.min.js

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@
  * @returns {Promise<EthereumProvider | null>} A Promise that resolves with the Provider if it
  * is detected within the given timeout, otherwise null.
  */
-module.exports = function detectProvider ({
+module.exports = function detectEthereumProvider ({
   mustBeMetaMask = false,
   timeout = 3000,
 } = {}) {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
     "test": "node test/*",
     "lint": "eslint . --ext js,json",
     "lint:fix": "eslint . --ext js,json --fix",
-    "build": "mkdir -p dist && yarn build:browser && yarn build:browser:min",
-    "build:browser": "browserify index.js > dist/detect-provider.js",
-    "build:browser:min": "browserify -g uglifyify index.js > dist/detect-provider.min.js",
+    "build": "./build.sh",
     "prepare": "yarn build"
   },
   "repository": {


### PR DESCRIPTION
- Move build scripts to `build.sh`
- Add `detectEthereumProvider` as global object using the `browserify` `-s` option
