### PR TITLE
Add silent mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,33 @@ if (provider) {
 ### Options
 
 The exported function takes an optional `options` object.
-In most cases, you won't need to specify anything, but read on for details.
+If invalid options are provided, an error will be thrown.
+All fields have default values.
 
 #### `options.mustBeMetaMask`
 
-Whether `window.ethereum.isMetaMask === true` is required for the returned Promise to resolve.
+Type: `boolean`
 
 Default: `false`
 
+Whether `window.ethereum.isMetaMask === true` is required for the returned Promise to resolve.
+
+#### `options.silent`
+
+Type: `boolean`
+
+Default: `false`
+
+Whether error messages should be logged to the console.
+Does not affect errors thrown due to invalid options.
+
 #### `options.timeout`
 
-How many milliseconds to wait for asynchronously injected providers.
+Type: `number`
 
 Default: `3000`
+
+How many milliseconds to wait for asynchronously injected providers.
 
 ## Advanced Topics
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ if (provider) {
 
 The exported function takes an optional `options` object.
 If invalid options are provided, an error will be thrown.
-All fields have default values.
+All options have default values.
 
 #### `options.mustBeMetaMask`
 

--- a/index.js
+++ b/index.js
@@ -7,22 +7,20 @@
  * @param {Object} [options] - Options bag.
  * @param {boolean} [options.mustBeMetaMask] - Whether to only look for MetaMask
  * providers. Default: false
+ * @param {boolean} [options.silent] - Whether to silence console errors. Does
+ * not affect thrown errors. Default: false
  * @param {number} [options.timeout] - Milliseconds to wait for
  * 'ethereum#initialized' to be dispatched. Default: 3000
- * @returns {Promise<EthereumProvider | null>} A Promise that resolves with the Provider if it
- * is detected within the given timeout, otherwise null.
+ * @returns {Promise<EthereumProvider | null>} A Promise that resolves with the
+ * Provider if it is detected within the given timeout, otherwise null.
  */
 module.exports = function detectEthereumProvider ({
   mustBeMetaMask = false,
+  silent = false,
   timeout = 3000,
 } = {}) {
 
-  if (typeof timeout !== 'number') {
-    throw new Error(`@metamask/detect-provider: Expected 'number' timeout.`)
-  }
-  if (typeof mustBeMetaMask !== 'boolean') {
-    throw new Error(`@metamask/detect-provider: Expected 'boolean' mustBeMetaMask.`)
-  }
+  _validateInputs()
 
   let handled = false
 
@@ -63,9 +61,21 @@ module.exports = function detectEthereumProvider ({
           ? 'Non-MetaMask window.ethereum detected.'
           : 'Unable to detect window.ethereum.'
 
-        console.error('@metamask/detect-provider:', message)
+        !silent && console.error('@metamask/detect-provider:', message)
         resolve(null)
       }
     }
   })
+
+  function _validateInputs () {
+    if (typeof mustBeMetaMask !== 'boolean') {
+      throw new Error(`@metamask/detect-provider: Expected option 'mustBeMetaMask' to be a boolean.`)
+    }
+    if (typeof silent !== 'boolean') {
+      throw new Error(`@metamask/detect-provider: Expected option 'silent' to be a boolean.`)
+    }
+    if (typeof timeout !== 'number') {
+      throw new Error(`@metamask/detect-provider: Expected option 'timeout' to be a number.`)
+    }
+  }
 }


### PR DESCRIPTION
Add `silent` as option, to silence `console.error` messages.