### PR TITLE
sample code fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please consult [the MetaMask documentation](https://docs.metamask.io/guide/ether
 ### Node.js
 
 ```javascript
-import detectEthereumProvider from '@metamask/detect-provider'
+const detectEthereumProvider = require('@metamask/detect-provider')
 
 const provider = await detectEthereumProvider()
 


### PR DESCRIPTION
from
```javascript
import detectEthereumProvider from '@metamask/detect-provider'
```

to
```javascript
const detectEthereumProvider = require('@metamask/detect-provider')
```
