### PR TITLE
Type resolve-value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,11 +30,11 @@ export = detectEthereumProvider;
  * @returns A Promise that resolves with the Provider if it is detected within
  * given timeout, otherwise null.
  */
-function detectEthereumProvider({
+function detectEthereumProvider<T = MetaMaskEthereumProvider>({
   mustBeMetaMask = false,
   silent = false,
   timeout = 3000,
-} = {}): Promise<MetaMaskEthereumProvider | null> {
+} = {}): Promise<T | null> {
 
   _validateInputs();
 
@@ -70,7 +70,7 @@ function detectEthereumProvider({
       const { ethereum } = window as Window;
 
       if (ethereum && (!mustBeMetaMask || ethereum.isMetaMask)) {
-        resolve(ethereum);
+        resolve(ethereum as unknown as T);
       } else {
 
         const message = mustBeMetaMask && ethereum

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,15 @@
-interface EthereumProvider {
+interface MetaMaskEthereumProvider {
   isMetaMask?: boolean;
+  once(eventName: string | symbol, listener: (...args: any[]) => void): this;
+  on(eventName: string | symbol, listener: (...args: any[]) => void): this;
+  off(eventName: string | symbol, listener: (...args: any[]) => void): this;
+  addListener(eventName: string | symbol, listener: (...args: any[]) => void): this;
+  removeListener(eventName: string | symbol, listener: (...args: any[]) => void): this;
+  removeAllListeners(event?: string | symbol): this;
 }
 
 interface Window {
-  ethereum?: EthereumProvider;
+  ethereum?: MetaMaskEthereumProvider;
 }
 
 export = detectEthereumProvider;
@@ -28,7 +34,7 @@ function detectEthereumProvider({
   mustBeMetaMask = false,
   silent = false,
   timeout = 3000,
-} = {}): Promise<unknown> {
+} = {}): Promise<MetaMaskEthereumProvider | null> {
 
   _validateInputs();
 


### PR DESCRIPTION
Changes in this PR allow you to use methods on the returned provider (in a TS project) without having to homecook your own type in your own codebase:

**before:**
```ts
type Provider = { on: (eventType: string, handler: () => unknown) => void }; // homecooking my own type
const provider = (await detectEthereumProvider()) as Provider;
provider.on('whenever', whatever);
```

**now:**
```ts
const provider = await detectEthereumProvider();
provider!.on('whenever', whatever);
```
or:
```ts
const provider = await detectEthereumProvider<MyCustomProvider>();
provider!.customProviderMethod();
```


---

Would love some feedback on whether this is a good idea or on why perhaps this might not be a great idea.