### PR TITLE
Adds support for delayed injection.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,9 @@ function detectEthereumProvider<T = MetaMaskEthereumProvider>({
     }
 
     function handleEthereum() {
-
+      if (!('ethereum' in window) {
+          return;
+      }
       if (handled) {
         return;
       }


### PR DESCRIPTION
A privacy respecting wallet will not inject into the page until *after* the user tells it to so websites cannot fingerprint the user.  Unfortunately, this script as currently written doesn't support this pattern because it only calls `handleEthereum` once and if the `timeout` is hit before `ethereum` is injected this will unsubscribe from the event listener and refuse any further attempts at connecting things up.

By checking for `ethereum` in window first in `handleEthereum`, if the timeout is hit but nothing is hooked up yet then the system will continue listening for the `ethereum#initialized` event indefinitely.