### PR TITLE
feat: select MetaMask provider when conflicts with Coinbase Wallet

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,15 +98,23 @@ function detectEthereumProvider<T = MetaMaskEthereumProvider>({
 
 function getEthereum(mustBeMetaMask: boolean) {
   const { ethereum } = window as Window;
-  if (!ethereum) return undefined;
+  if (!ethereum) {
+    return undefined;
+  }
   // The `providers` field is populated when CoinBase Wallet extension is also installed
   // The expected object is an array of providers, the MetaMask provider is inside
   // See https://docs.cloud.coinbase.com/wallet-sdk/docs/injected-provider-guidance for more information
   if (Array.isArray(ethereum.providers)) {
-    if (mustBeMetaMask) return ethereum.providers.find(p => p.isMetaMask);
+    if (mustBeMetaMask) {
+      return ethereum.providers.find((p) => p.isMetaMask);
+    }
     return ethereum.providers[0];
   }
-  if (!mustBeMetaMask) return ethereum;
-  if (!ethereum.isMetaMask) return undefined;
+  if (!mustBeMetaMask) {
+    return ethereum;
+  }
+  if (!ethereum.isMetaMask) {
+    return undefined;
+  }
   return ethereum;
 }

--- a/test/spec.js
+++ b/test/spec.js
@@ -24,9 +24,31 @@ const providerWithMetaMask = {
 const providerNoMetaMask = {}
 const noProvider = null
 
+const manyProvidersWithMetaMask = {
+  providers: [{ isMetaMask: true }],
+}
+const manyProvidersWithoutMetaMask = {
+  providers: [{}],
+}
+const manyProvidersNoProvider = {
+  providers: [],
+}
+
 test('detectProvider: defaults with ethereum already set', async function (t) {
 
   mockGlobalProps(providerNoMetaMask)
+
+  const provider = await detectProvider()
+
+  t.deepEquals({}, provider, 'resolve with expected provider')
+  t.ok(window.addEventListener.notCalled, 'addEventListener should not have been called')
+  t.ok(window.removeEventListener.calledOnce, 'removeEventListener called once')
+  t.end()
+})
+
+test('detectProvider: defaults with ethereum already set in `providers` array field', async function (t) {
+
+  mockGlobalProps(manyProvidersWithoutMetaMask)
 
   const provider = await detectProvider()
 
@@ -48,9 +70,32 @@ test('detectProvider: mustBeMetamask with ethereum already set', async function 
   t.end()
 })
 
+test('detectProvider: mustBeMetamask with ethereum already set in `providers` array field', async function (t) {
+
+  mockGlobalProps(manyProvidersWithMetaMask)
+
+  const provider = await detectProvider()
+
+  t.ok(provider.isMetaMask, 'should have resolved expected provider object')
+  t.ok(window.addEventListener.notCalled, 'addEventListener should not have been called')
+  t.ok(window.removeEventListener.calledOnce, 'removeEventListener called once')
+  t.end()
+})
+
 test('detectProvider: mustBeMetamask with non-MetaMask ethereum already set', async function (t) {
 
   mockGlobalProps(providerNoMetaMask)
+
+  const result = await detectProvider({ timeout: 1, mustBeMetaMask: true })
+  t.equal(result, null, 'promise should have resolved null')
+  t.ok(window.addEventListener.notCalled, 'addEventListener should not have been called')
+  t.ok(window.removeEventListener.calledOnce, 'removeEventListener called once')
+  t.end()
+})
+
+test('detectProvider: mustBeMetamask with non-MetaMask ethereum already set in `providers` array field', async function (t) {
+
+  mockGlobalProps(manyProvidersWithoutMetaMask)
 
   const result = await detectProvider({ timeout: 1, mustBeMetaMask: true })
   t.equal(result, null, 'promise should have resolved null')
@@ -114,6 +159,18 @@ test('detectProvider: ethereum never set', async function (t) {
   const result = await detectProvider({ timeout: 1 })
   t.equal(result, null, 'promise should have resolved null')
   t.ok(window.addEventListener.calledOnce, 'addEventListener should have been called once')
+  t.ok(window.removeEventListener.calledOnce, 'removeEventListener should have been called once')
+  t.ok(console.error.calledOnce, 'console.error should have been called once')
+  t.end()
+})
+
+test('detectProvider: ethereum never set with `providers` array field', async function (t) {
+
+  mockGlobalProps(manyProvidersNoProvider)
+
+  const result = await detectProvider({ timeout: 1 })
+  t.equal(result, null, 'promise should have resolved null')
+  t.ok(window.addEventListener.notCalled, 'addEventListener should have been called once')
   t.ok(window.removeEventListener.calledOnce, 'removeEventListener should have been called once')
   t.ok(console.error.calledOnce, 'console.error should have been called once')
   t.end()


### PR DESCRIPTION
## Summary

When Coinbase Wallet and MetaMask extensions are both installed, the Coinbase Wallet Extension will modify the ethereum object of the window. According to their [documentation](https://docs.cloud.coinbase.com/wallet-sdk/docs/injected-provider-guidance), the advised solution is to loop over the new ethereum.providers field in order to find the proper provider.

This PR includes the advised changes.

Codesandbox for the issue: https://codesandbox.io/s/charming-burnell-x7jqq7?file=/src/App.tsx

Resolves #53 