### PR TITLE
fix: mustBeMetaMask should not detect brave as MetaMask

### DIFF
--- a/src/detect-ethereum-provider.ts
+++ b/src/detect-ethereum-provider.ts
@@ -56,7 +56,7 @@ export function detectEthereumProvider<T = MetaMaskEthereumProvider>({
 
       const { ethereum } = window as WindowWithEthereum;
 
-      if (ethereum && (!mustBeMetaMask || ethereum.isMetaMask)) {
+      if (ethereum && (!mustBeMetaMask || (ethereum.isMetaMask && !ethereum.isBraveWallet))) {
         resolve(ethereum as unknown as T);
       } else {
 

--- a/src/metamask-ethereum-provider.ts
+++ b/src/metamask-ethereum-provider.ts
@@ -1,5 +1,6 @@
 export interface MetaMaskEthereumProvider {
   isMetaMask?: boolean;
+  isBraveWallet?: boolean;
   once(eventName: string | symbol, listener: (...args: any[]) => void): this;
   on(eventName: string | symbol, listener: (...args: any[]) => void): this;
   off(eventName: string | symbol, listener: (...args: any[]) => void): this;

--- a/test/spec.js
+++ b/test/spec.js
@@ -21,6 +21,10 @@ const mockGlobalProps = (ethereum) => {
 const providerWithMetaMask = {
   isMetaMask: true,
 }
+const providerWithBrave = {
+  isMetaMask: true,
+  isBraveWallet: true,
+}
 const providerNoMetaMask = {}
 const noProvider = null
 
@@ -43,6 +47,17 @@ test('detectEthereumProvider: mustBeMetamask with ethereum already set', async f
   const provider = await detectEthereumProvider()
 
   t.ok(provider.isMetaMask, 'should have resolved expected provider object')
+  t.ok(window.addEventListener.notCalled, 'addEventListener should not have been called')
+  t.ok(window.removeEventListener.calledOnce, 'removeEventListener called once')
+  t.end()
+})
+
+test('detectEthereumProvider: mustBeMetamask with Brave ethereum already set', async function (t) {
+
+  mockGlobalProps(providerWithBrave)
+
+  const result = await detectEthereumProvider({ timeout: 1, mustBeMetaMask: true })
+  t.equal(result, null, 'promise should have resolved null')
   t.ok(window.addEventListener.notCalled, 'addEventListener should not have been called')
   t.ok(window.removeEventListener.calledOnce, 'removeEventListener called once')
   t.end()


### PR DESCRIPTION
Brave Wallet's `window.ethereum` sets `isMetaMask` to true, hence using the `mustBeMetaMask` option here will falsely detect Brave as MM, see:

https://github.com/brave/brave-core/blob/ae4c9dab752c588fc7b5921863f862777a19589d/components/brave_wallet/renderer/js_ethereum_provider.cc#L254-L256

This is a non-standard behavior of Brave as opposed to most MetaMask impersonators setting `isMetaMask` to false, hence requires explicit handling. Thankfully, a `isBraveWallet` property is also exposed (https://github.com/brave/brave-core/pull/12794), which we can check for to guard against wrongly detecting Brave as MM.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to provider detection when mustBeMetaMask is true; default detection behavior is unchanged for non-Brave providers.
> 
> **Overview**
> When **`mustBeMetaMask`** is enabled, detection no longer treats Brave Wallet as MetaMask. Brave’s injected provider sets **`isMetaMask: true`**, so the previous check could return Brave as a match; the resolver now also requires **`!ethereum.isBraveWallet`**.
> 
> The **`MetaMaskEthereumProvider`** type gains optional **`isBraveWallet`**, and a test asserts that **`mustBeMetaMask: true`** resolves to **`null`** when the mock provider has both flags set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b990296e74b969dac1504f58f362616276752cdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->